### PR TITLE
Add capacity to get Header from a Request object

### DIFF
--- a/src/main/java/com/pwdd/server/request/Request.java
+++ b/src/main/java/com/pwdd/server/request/Request.java
@@ -1,12 +1,14 @@
 package com.pwdd.server.request;
 
 import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 public class Request {
   private HashMap<String, String> parsedRequest;
 
-  public Request(HashMap<String, String> _parsedRequest) {
-    this.parsedRequest = _parsedRequest;
+  public Request(HashMap<String, String> parsedRequest) {
+    this.parsedRequest = parsedRequest;
   }
 
   public String getBody() {
@@ -19,5 +21,31 @@ public class Request {
 
   public String getURI() {
     return parsedRequest.get("URI");
+  }
+
+  public String getProtocol() {
+    return parsedRequest.get("Protocol");
+  }
+
+  public String getHeader() {
+    return getMethod() + " " + getURI() + " " + getProtocol();
+  }
+
+  public String getFullHeader() {
+    StringBuilder builder = new StringBuilder();
+    builder.append(getHeader()).append("\r\n");
+
+    for (Map.Entry<String, String> entry : parsedRequest.entrySet()) {
+      String key = entry.getKey();
+      if (!Objects.equals(key, "Body") && !isFirstLineHeader(key)) {
+        builder.append(key).append(": ");
+        builder.append(entry.getValue()).append("\r\n");
+      }
+    }
+    return builder.append("\r\b").toString();
+  }
+
+  private boolean isFirstLineHeader(String key) {
+    return Objects.equals(key, "Method") || Objects.equals(key, "URI") || Objects.equals(key, "Protocol");
   }
 }

--- a/src/main/java/com/pwdd/server/request/RequestParser.java
+++ b/src/main/java/com/pwdd/server/request/RequestParser.java
@@ -46,15 +46,15 @@ public final class RequestParser {
       }
     }
     if (contentLength > 0) {
-      getBody(buf, request, contentLength);
+      request.append(getBody(buf, contentLength));
     }
     return request.toString();
   }
 
-  private static void getBody(BufferedReader buf, StringBuilder base, int size) throws IOException {
+  private static String getBody(BufferedReader buf, int size) throws IOException {
     char[] body = new char[size];
     buf.read(body);
-    base.append("Body: ").append(new String(body)).append(IResponder.CRLF);
+    return "Body: " + new String(body) + IResponder.CRLF;
   }
 
   private static String[] stringToStringArray(String in) {

--- a/src/test/java/com/pwdd/server/request/RequestTest.java
+++ b/src/test/java/com/pwdd/server/request/RequestTest.java
@@ -1,0 +1,68 @@
+package com.pwdd.server.request;
+
+import org.junit.*;
+
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class RequestTest {
+  private HashMap<String, String> parsedRequest = getParsedRequest();
+
+  private Request request = new Request(parsedRequest);
+
+  private HashMap<String, String> getParsedRequest() {
+    HashMap<String, String> parsedRequest = new HashMap<>();
+    parsedRequest.put("Method", "GET");
+    parsedRequest.put("URI", "/foo");
+    parsedRequest.put("Protocol", "HTTP/1.1");
+    parsedRequest.put("Host", "localhost");
+    parsedRequest.put("Accept", "text/html");
+    parsedRequest.put("Keep-Alive", "300");
+    parsedRequest.put("ConnectionManager", "keep-alive");
+    parsedRequest.put("Body", "hello");
+    return parsedRequest;
+  }
+
+  @Test
+  public void getBodyTest() {
+    assertEquals("hello", request.getBody());
+  }
+
+  @Test
+  public void getMethodTest() {
+    assertEquals("GET", request.getMethod());
+  }
+
+  @Test
+  public void getURITest() {
+    assertEquals("/foo", request.getURI());
+  }
+
+  @Test
+  public void getProtocolTest() {
+    assertEquals("HTTP/1.1", request.getProtocol());
+  }
+
+  @Test
+  public void getHeaderTest() {
+    assertEquals("GET /foo HTTP/1.1", request.getHeader());
+  }
+
+  @Test
+  public void getFullHeaderHasOnlyHeaderTest() {
+    String fullHeader = request.getFullHeader();
+    assertTrue(fullHeader.contains(request.getHeader()));
+    assertTrue(fullHeader.contains("Host: localhost"));
+    assertTrue(fullHeader.contains("Keep-Alive: 300"));
+    assertTrue(fullHeader.contains("Accept: text/html"));
+    assertTrue(fullHeader.contains("ConnectionManager: keep-alive"));
+  }
+
+  @Test
+  public void getFullHeaderDoesNotHaveBodyTest() {
+    String fullHeader = request.getFullHeader();
+    assertTrue(!fullHeader.contains(request.getBody()));
+  }
+}


### PR DESCRIPTION
- Refactor initialization: just rename parameter
- Refactor RequestParser: remove one parameter
- Add getHeader() to Request
- Add getFullHeader() to Request